### PR TITLE
Scroll management API implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -310,6 +310,7 @@
 							<generateModelTests>false</generateModelTests>
 							<configOptions>
 								<controllerThrowsExceptions>java.io.IOException,com.example.NotFoundException</controllerThrowsExceptions>
+                                <unhandledException>true</unhandledException> <!--  -->
 								<interfaceOnly>true</interfaceOnly>
 								<skipDefaultInterface>true</skipDefaultInterface>
 								<useBeanValidation>true</useBeanValidation>

--- a/src/main/java/com/mf/HerculaneumTranscriptor/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/mf/HerculaneumTranscriptor/controller/GlobalExceptionHandler.java
@@ -1,7 +1,7 @@
 package com.mf.HerculaneumTranscriptor.controller;
 
 import com.mf.HerculaneumTranscriptor.exception.ResourceNotFoundException;
-import com.mf.HerculaneumTranscriptor.exception.UserAlreadyExistsException;
+import com.mf.HerculaneumTranscriptor.exception.ResourceAlreadyExistsException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -29,11 +29,11 @@ public class GlobalExceptionHandler {
     return new ResponseEntity<>(body, status);
   }
 
-  @ExceptionHandler(UserAlreadyExistsException.class)
+  @ExceptionHandler(ResourceAlreadyExistsException.class)
   public ResponseEntity<Object> handleUserAlreadyExists(
-          UserAlreadyExistsException ex, WebRequest request) {
+          ResourceAlreadyExistsException ex, WebRequest request) {
 
-    return buildResponseBody(HttpStatus.CONFLICT, "User conflict", ex.getMessage());
+    return buildResponseBody(HttpStatus.CONFLICT, "Resource conflict", ex.getMessage());
   }
 
   @ExceptionHandler(ResourceNotFoundException.class)

--- a/src/main/java/com/mf/HerculaneumTranscriptor/controller/ScrollController.java
+++ b/src/main/java/com/mf/HerculaneumTranscriptor/controller/ScrollController.java
@@ -1,0 +1,36 @@
+package com.mf.HerculaneumTranscriptor.controller;
+
+import lombok.AllArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import scroll.api.ScrollsApi;
+import scroll.dto.NewScroll;
+import scroll.dto.Scroll;
+
+import java.util.List;
+
+@RestController
+@AllArgsConstructor
+public class ScrollController implements ScrollsApi {
+  @Override
+  public ResponseEntity<Scroll> createScroll(NewScroll metadata, MultipartFile inkImage) {
+    return null;
+  }
+
+  @Override
+  public ResponseEntity<Void> deleteScroll(String scrollId) {
+    return null;
+  }
+
+  @Override
+  public ResponseEntity<List<Scroll>> getAllScrolls() {
+    return null;
+  }
+
+  @Override
+  public ResponseEntity<Resource> getScrollImage(String scrollId) {
+    return null;
+  }
+}

--- a/src/main/java/com/mf/HerculaneumTranscriptor/controller/ScrollController.java
+++ b/src/main/java/com/mf/HerculaneumTranscriptor/controller/ScrollController.java
@@ -1,5 +1,6 @@
 package com.mf.HerculaneumTranscriptor.controller;
 
+import com.mf.HerculaneumTranscriptor.service.ScrollService;
 import lombok.AllArgsConstructor;
 import org.springframework.core.io.Resource;
 import org.springframework.http.ResponseEntity;
@@ -9,14 +10,18 @@ import scroll.api.ScrollsApi;
 import scroll.dto.NewScroll;
 import scroll.dto.Scroll;
 
+import java.io.IOException;
 import java.util.List;
 
 @RestController
 @AllArgsConstructor
 public class ScrollController implements ScrollsApi {
+  private final ScrollService scrollService;
+
   @Override
-  public ResponseEntity<Scroll> createScroll(NewScroll metadata, MultipartFile inkImage) {
-    return null;
+  public ResponseEntity<Scroll> createScroll(NewScroll metadata, MultipartFile inkImage) throws IOException {
+    Scroll scroll = scrollService.createScroll(metadata, inkImage);
+    return ResponseEntity.ok(scroll);
   }
 
   @Override
@@ -26,7 +31,8 @@ public class ScrollController implements ScrollsApi {
 
   @Override
   public ResponseEntity<List<Scroll>> getAllScrolls() {
-    return null;
+    List<Scroll> scrolls = scrollService.getAllScrolls();
+    return ResponseEntity.ok(scrolls);
   }
 
   @Override

--- a/src/main/java/com/mf/HerculaneumTranscriptor/controller/ScrollController.java
+++ b/src/main/java/com/mf/HerculaneumTranscriptor/controller/ScrollController.java
@@ -25,8 +25,9 @@ public class ScrollController implements ScrollsApi {
   }
 
   @Override
-  public ResponseEntity<Void> deleteScroll(String scrollId) {
-    return null;
+  public ResponseEntity<Void> deleteScroll(String scrollId) throws IOException {
+    scrollService.deleteScroll(scrollId);
+    return ResponseEntity.ok().build();
   }
 
   @Override
@@ -36,7 +37,8 @@ public class ScrollController implements ScrollsApi {
   }
 
   @Override
-  public ResponseEntity<Resource> getScrollImage(String scrollId) {
-    return null;
+  public ResponseEntity<Resource> getScrollImage(String scrollId) throws IOException {
+    Resource inkImage = scrollService.getScrollImage(scrollId);
+    return ResponseEntity.ok(inkImage);
   }
 }

--- a/src/main/java/com/mf/HerculaneumTranscriptor/controller/ScrollController.java
+++ b/src/main/java/com/mf/HerculaneumTranscriptor/controller/ScrollController.java
@@ -41,4 +41,10 @@ public class ScrollController implements ScrollsApi {
     Resource inkImage = scrollService.getScrollImage(scrollId);
     return ResponseEntity.ok(inkImage);
   }
+
+  @Override
+  public ResponseEntity<Scroll> updateScroll(String scrollId, NewScroll newScroll) {
+    Scroll scroll = scrollService.updateScroll(scrollId, newScroll);
+    return ResponseEntity.ok(scroll);
+  }
 }

--- a/src/main/java/com/mf/HerculaneumTranscriptor/domain/Scroll.java
+++ b/src/main/java/com/mf/HerculaneumTranscriptor/domain/Scroll.java
@@ -1,0 +1,27 @@
+package com.mf.HerculaneumTranscriptor.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.Instant;
+
+@Entity @Table(name="SCROLLS")
+@Getter @Setter @AllArgsConstructor @NoArgsConstructor
+public class Scroll {
+  @Id
+  @GeneratedValue(strategy= GenerationType.AUTO)
+  private Long id;
+
+  private String scrollId;
+  private String displayName;
+  private String description;
+  private String imagePath;
+  private String thumbnailUrl;
+
+  @CreationTimestamp
+  private Instant createdAt;
+}

--- a/src/main/java/com/mf/HerculaneumTranscriptor/domain/mapper/ScrollMapper.java
+++ b/src/main/java/com/mf/HerculaneumTranscriptor/domain/mapper/ScrollMapper.java
@@ -1,0 +1,15 @@
+package com.mf.HerculaneumTranscriptor.domain.mapper;
+
+import com.mf.HerculaneumTranscriptor.domain.Scroll;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import scroll.dto.NewScroll;
+
+@Mapper(componentModel = "spring")
+public interface ScrollMapper {
+  @Mapping(target = "imagePath", ignore = true) // This will be set manually in the service.
+  @Mapping(target = "createdAt", ignore = true) // The database generates the timestamp.
+  Scroll newScrollDtoToScrollEntity(NewScroll newScroll);
+
+  scroll.dto.Scroll scrollEntityToScrollDto(Scroll scroll);
+}

--- a/src/main/java/com/mf/HerculaneumTranscriptor/domain/mapper/ScrollMapper.java
+++ b/src/main/java/com/mf/HerculaneumTranscriptor/domain/mapper/ScrollMapper.java
@@ -5,6 +5,9 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import scroll.dto.NewScroll;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 @Mapper(componentModel = "spring")
 public interface ScrollMapper {
   @Mapping(target = "imagePath", ignore = true) // This will be set manually in the service.
@@ -12,4 +15,20 @@ public interface ScrollMapper {
   Scroll newScrollDtoToScrollEntity(NewScroll newScroll);
 
   scroll.dto.Scroll scrollEntityToScrollDto(Scroll scroll);
+
+  default String uriToString(URI uri) {
+    return (uri == null) ? null : uri.toString();
+  }
+
+  default URI stringToUri(String uriString) {
+    if (uriString == null || uriString.isBlank()) {
+      return null;
+    }
+    try {
+      return new URI(uriString);
+    } catch (URISyntaxException e) {
+      System.err.println("Failed to parse URI string from database: " + uriString);
+      return null;
+    }
+  }
 }

--- a/src/main/java/com/mf/HerculaneumTranscriptor/exception/ResourceAlreadyExistsException.java
+++ b/src/main/java/com/mf/HerculaneumTranscriptor/exception/ResourceAlreadyExistsException.java
@@ -2,9 +2,9 @@ package com.mf.HerculaneumTranscriptor.exception;
 /**
  * This exception is thrown when a user tries to register with an already used username or email.
  */
-public class UserAlreadyExistsException extends RuntimeException {
+public class ResourceAlreadyExistsException extends RuntimeException {
 
-  public UserAlreadyExistsException(String message) {
+  public ResourceAlreadyExistsException(String message) {
     super(message);
   }
 }

--- a/src/main/java/com/mf/HerculaneumTranscriptor/repository/ScrollRepository.java
+++ b/src/main/java/com/mf/HerculaneumTranscriptor/repository/ScrollRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface ScrollRepository extends CrudRepository<Scroll, Long> {
   Optional<Scroll> findByScrollId(String scrollId);
+  Boolean existsByScrollId(String scrollId);
 }

--- a/src/main/java/com/mf/HerculaneumTranscriptor/repository/ScrollRepository.java
+++ b/src/main/java/com/mf/HerculaneumTranscriptor/repository/ScrollRepository.java
@@ -1,0 +1,10 @@
+package com.mf.HerculaneumTranscriptor.repository;
+
+import com.mf.HerculaneumTranscriptor.domain.Scroll;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface ScrollRepository extends CrudRepository<Scroll, Long> {
+  Optional<Scroll> findByScrollId(String scrollId);
+}

--- a/src/main/java/com/mf/HerculaneumTranscriptor/service/ScrollService.java
+++ b/src/main/java/com/mf/HerculaneumTranscriptor/service/ScrollService.java
@@ -59,4 +59,17 @@ public interface ScrollService {
    */
   Resource getScrollImage(String scrollId) throws ResourceNotFoundException, IOException;
 
+  /**
+   * Updates the metadata of a specific scroll.
+   * This operation is restricted to ROOT or ADMIN users.
+   *
+   * @param scrollId The unique identifier of the scroll to update.
+   * @param newScroll The DTO containing the updated scroll's details.
+   * @return The updated Scroll DTO.
+   * @throws com.mf.HerculaneumTranscriptor.exception.ResourceAlreadyExistsException if a scroll with the same ID already exists.
+   * @throws com.mf.HerculaneumTranscriptor.exception.ResourceNotFoundException if the scroll does not exist.
+   */
+  @PreAuthorize("hasRole('ROOT') or hasRole('ADMIN')")
+  Scroll updateScroll(String scrollId, NewScroll newScroll) throws ResourceAlreadyExistsException, ResourceNotFoundException;
+
 }

--- a/src/main/java/com/mf/HerculaneumTranscriptor/service/ScrollService.java
+++ b/src/main/java/com/mf/HerculaneumTranscriptor/service/ScrollService.java
@@ -57,6 +57,6 @@ public interface ScrollService {
    * @return A Spring Resource object pointing to the image file.
    * @throws com.mf.HerculaneumTranscriptor.exception.ResourceNotFoundException if the scroll or its image does not exist.
    */
-  Resource getScrollImage(String scrollId) throws ResourceNotFoundException;
+  Resource getScrollImage(String scrollId) throws ResourceNotFoundException, IOException;
 
 }

--- a/src/main/java/com/mf/HerculaneumTranscriptor/service/ScrollService.java
+++ b/src/main/java/com/mf/HerculaneumTranscriptor/service/ScrollService.java
@@ -1,0 +1,62 @@
+package com.mf.HerculaneumTranscriptor.service;
+
+import com.mf.HerculaneumTranscriptor.exception.ResourceAlreadyExistsException;
+import com.mf.HerculaneumTranscriptor.exception.ResourceNotFoundException;
+import org.springframework.core.io.Resource;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.multipart.MultipartFile;
+import scroll.dto.NewScroll;
+import scroll.dto.Scroll;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Service layer defining business operations related to Scrolls.
+ * This interface is independent of the web/controller layer.
+ */
+public interface ScrollService {
+
+  /**
+   * Retrieves a list of all scrolls available in the system.
+   * This is a public operation for any authenticated user.
+   *
+   * @return A list of Scroll DTOs.
+   */
+  List<Scroll> getAllScrolls();
+
+  /**
+   * Creates a new scroll and stores its associated ink prediction image.
+   * This operation is restricted to ROOT or ADMIN users.
+   *
+   * @param metadata The DTO containing the new scroll's details.
+   * @param inkImage The ink prediction image file in PNG format.
+   * @return The newly created Scroll DTO.
+   * @throws com.mf.HerculaneumTranscriptor.exception.ResourceAlreadyExistsException if a scroll with the same ID already exists.
+   * @throws java.io.IOException if there is an error saving the image file.
+   */
+  @PreAuthorize("hasRole('ROOT') or hasRole('ADMIN')")
+  Scroll createScroll(NewScroll metadata, MultipartFile inkImage) throws ResourceAlreadyExistsException, IOException;
+
+  /**
+   * Deletes a scroll and its associated image file from the system.
+   * This is a destructive operation restricted to ROOT or ADMIN users.
+   *
+   * @param scrollId The unique identifier of the scroll to delete.
+   * @throws com.mf.HerculaneumTranscriptor.exception.ResourceNotFoundException if the scroll does not exist.
+   * @throws java.io.IOException if there is an error deleting the image file.
+   */
+  @PreAuthorize("hasRole('ROOT') or hasRole('ADMIN')")
+  void deleteScroll(String scrollId) throws ResourceNotFoundException, IOException;
+
+  /**
+   * Retrieves the ink prediction image for a specific scroll as a loadable resource.
+   * Any authenticated user can download the image.
+   *
+   * @param scrollId The unique identifier of the scroll.
+   * @return A Spring Resource object pointing to the image file.
+   * @throws com.mf.HerculaneumTranscriptor.exception.ResourceNotFoundException if the scroll or its image does not exist.
+   */
+  Resource getScrollImage(String scrollId) throws ResourceNotFoundException;
+
+}

--- a/src/main/java/com/mf/HerculaneumTranscriptor/service/UserService.java
+++ b/src/main/java/com/mf/HerculaneumTranscriptor/service/UserService.java
@@ -2,7 +2,7 @@ package com.mf.HerculaneumTranscriptor.service;
 
 import com.mf.HerculaneumTranscriptor.dto.AuthenticationResponse;
 import com.mf.HerculaneumTranscriptor.exception.ResourceNotFoundException;
-import com.mf.HerculaneumTranscriptor.exception.UserAlreadyExistsException;
+import com.mf.HerculaneumTranscriptor.exception.ResourceAlreadyExistsException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.AuthenticationException;
 import user.dto.*;
@@ -20,9 +20,9 @@ public interface UserService {
    *
    * @param registrationInfo DTO containing new user details.
    * @return An AuthenticationResponse containing the JWT andUserInfo of the newly created user.
-   * @throws com.mf.HerculaneumTranscriptor.exception.UserAlreadyExistsException if username or email is taken.
+   * @throws ResourceAlreadyExistsException if username or email is taken.
    */
-  AuthenticationResponse registerNewUser(UserRegisterInfo registrationInfo) throws UserAlreadyExistsException;
+  AuthenticationResponse registerNewUser(UserRegisterInfo registrationInfo) throws ResourceAlreadyExistsException;
 
   /**
    * Authenticates a user and generates an access token.
@@ -71,10 +71,10 @@ public interface UserService {
    * @param username The username of the user to update.
    * @param updateInfo DTO with the new profile information.
    * @throws com.mf.HerculaneumTranscriptor.exception.ResourceNotFoundException if no user is found.
-   * @throws com.mf.HerculaneumTranscriptor.exception.UserAlreadyExistsException if desired new username is taken.
+   * @throws ResourceAlreadyExistsException if desired new username is taken.
    */
   @PreAuthorize("hasRole('ROOT') or @securityLogic.hasAuthorityOver(authentication, #username)")
-  void updateUserProfile(String username, ChangeUserInfo updateInfo) throws ResourceNotFoundException, UserAlreadyExistsException;
+  void updateUserProfile(String username, ChangeUserInfo updateInfo) throws ResourceNotFoundException, ResourceAlreadyExistsException;
 
   /**
    * Changes the permission level for a given user.

--- a/src/main/java/com/mf/HerculaneumTranscriptor/service/impl/ScrollServiceImpl.java
+++ b/src/main/java/com/mf/HerculaneumTranscriptor/service/impl/ScrollServiceImpl.java
@@ -74,7 +74,10 @@ public class ScrollServiceImpl implements ScrollService {
     scrollRepository.delete(scroll); // Deletes the metadata from the DB
 
     Path filePath = storageLocation.resolve(scroll.getImagePath()).normalize();
-    Files.delete(filePath);
+
+    // In the improbable case the image does not exist, do not try to delete it
+    if (Files.exists(filePath))
+      Files.delete(filePath);
   }
 
   @Override

--- a/src/main/java/com/mf/HerculaneumTranscriptor/service/impl/ScrollServiceImpl.java
+++ b/src/main/java/com/mf/HerculaneumTranscriptor/service/impl/ScrollServiceImpl.java
@@ -86,4 +86,23 @@ public class ScrollServiceImpl implements ScrollService {
     InputStream in = Files.newInputStream(filePath);
     return new InputStreamResource(in);
   }
+
+  @Override
+  public Scroll updateScroll(String scrollId, NewScroll metadata) throws ResourceAlreadyExistsException, ResourceNotFoundException {
+    com.mf.HerculaneumTranscriptor.domain.Scroll scroll = scrollRepository.findByScrollId(scrollId)
+            .orElseThrow(() -> new ResourceNotFoundException("Scroll not found"));
+
+    if (!scrollId.equals(metadata.getScrollId()) && scrollRepository.existsByScrollId(metadata.getScrollId())) {
+      throw new ResourceAlreadyExistsException("Scroll with ID '" + metadata.getScrollId() + "' already exists.");
+    }
+
+    scroll.setDescription(metadata.getDescription());
+    scroll.setDisplayName(metadata.getDisplayName());
+    scroll.setScrollId(metadata.getScrollId());
+    scroll.setThumbnailUrl(scrollMapper.uriToString(metadata.getThumbnailUrl()));
+
+    // Update scroll entry
+    com.mf.HerculaneumTranscriptor.domain.Scroll updatedScroll = scrollRepository.save(scroll);
+    return scrollMapper.scrollEntityToScrollDto(updatedScroll);
+  }
 }

--- a/src/main/java/com/mf/HerculaneumTranscriptor/service/impl/ScrollServiceImpl.java
+++ b/src/main/java/com/mf/HerculaneumTranscriptor/service/impl/ScrollServiceImpl.java
@@ -1,0 +1,43 @@
+package com.mf.HerculaneumTranscriptor.service.impl;
+
+import com.mf.HerculaneumTranscriptor.domain.mapper.ScrollMapper;
+import com.mf.HerculaneumTranscriptor.exception.ResourceAlreadyExistsException;
+import com.mf.HerculaneumTranscriptor.exception.ResourceNotFoundException;
+import com.mf.HerculaneumTranscriptor.repository.ScrollRepository;
+import com.mf.HerculaneumTranscriptor.service.ScrollService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import scroll.dto.NewScroll;
+import scroll.dto.Scroll;
+
+import java.io.IOException;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ScrollServiceImpl implements ScrollService {
+  private final ScrollRepository scrollRepository;
+  private final ScrollMapper scrollMapper;
+
+  @Override
+  public List<Scroll> getAllScrolls() {
+    return List.of();
+  }
+
+  @Override
+  public Scroll createScroll(NewScroll metadata, MultipartFile inkImage) throws ResourceAlreadyExistsException, IOException {
+    return null;
+  }
+
+  @Override
+  public void deleteScroll(String scrollId) throws ResourceNotFoundException, IOException {
+
+  }
+
+  @Override
+  public Resource getScrollImage(String scrollId) throws ResourceNotFoundException {
+    return null;
+  }
+}

--- a/src/main/java/com/mf/HerculaneumTranscriptor/service/impl/ScrollServiceImpl.java
+++ b/src/main/java/com/mf/HerculaneumTranscriptor/service/impl/ScrollServiceImpl.java
@@ -68,11 +68,22 @@ public class ScrollServiceImpl implements ScrollService {
 
   @Override
   public void deleteScroll(String scrollId) throws ResourceNotFoundException, IOException {
+    com.mf.HerculaneumTranscriptor.domain.Scroll scroll = scrollRepository.findByScrollId(scrollId)
+            .orElseThrow(() -> new ResourceNotFoundException("Scroll not found"));
 
+    scrollRepository.delete(scroll); // Deletes the metadata from the DB
+
+    Path filePath = storageLocation.resolve(scroll.getImagePath()).normalize();
+    Files.delete(filePath);
   }
 
   @Override
-  public Resource getScrollImage(String scrollId) throws ResourceNotFoundException {
-    return null;
+  public Resource getScrollImage(String scrollId) throws ResourceNotFoundException, IOException {
+    com.mf.HerculaneumTranscriptor.domain.Scroll scroll = scrollRepository.findByScrollId(scrollId)
+            .orElseThrow(() -> new ResourceNotFoundException("Scroll not found"));
+
+    Path filePath = storageLocation.resolve(scroll.getImagePath()).normalize();
+    InputStream in = Files.newInputStream(filePath);
+    return new InputStreamResource(in);
   }
 }

--- a/src/main/java/com/mf/HerculaneumTranscriptor/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/mf/HerculaneumTranscriptor/service/impl/UserServiceImpl.java
@@ -4,7 +4,7 @@ import com.mf.HerculaneumTranscriptor.domain.User;
 import com.mf.HerculaneumTranscriptor.domain.mapper.UserMapper;
 import com.mf.HerculaneumTranscriptor.dto.AuthenticationResponse;
 import com.mf.HerculaneumTranscriptor.exception.ResourceNotFoundException;
-import com.mf.HerculaneumTranscriptor.exception.UserAlreadyExistsException;
+import com.mf.HerculaneumTranscriptor.exception.ResourceAlreadyExistsException;
 import com.mf.HerculaneumTranscriptor.repository.UserRepository;
 import com.mf.HerculaneumTranscriptor.security.JwtUtil;
 import com.mf.HerculaneumTranscriptor.service.UserService;
@@ -34,10 +34,10 @@ public class UserServiceImpl implements UserService {
   private final PasswordEncoder passwordEncoder;
 
   @Override
-  public AuthenticationResponse registerNewUser(UserRegisterInfo registrationInfo) throws UserAlreadyExistsException {
+  public AuthenticationResponse registerNewUser(UserRegisterInfo registrationInfo) throws ResourceAlreadyExistsException {
     // Check if username is already taken
     if (userRepository.existsByUsername(registrationInfo.getBasicInfo().getUsername()))
-      throw new UserAlreadyExistsException("Username is already taken: " + registrationInfo.getBasicInfo().getUsername());
+      throw new ResourceAlreadyExistsException("Username is already taken: " + registrationInfo.getBasicInfo().getUsername());
 
     User user = userMapper.userRegisterInfoToUser(registrationInfo);
     user.setPasswordHash(passwordEncoder.encode(registrationInfo.getPassword()));
@@ -94,7 +94,7 @@ public class UserServiceImpl implements UserService {
   }
 
   @Override
-  public void updateUserProfile(String username, ChangeUserInfo updateInfo) throws ResourceNotFoundException, UserAlreadyExistsException {
+  public void updateUserProfile(String username, ChangeUserInfo updateInfo) throws ResourceNotFoundException, ResourceAlreadyExistsException {
     User originalUser = userRepository.findByUsername(username)
             .orElseThrow(() -> new ResourceNotFoundException("User not found: " + username));
 
@@ -104,7 +104,7 @@ public class UserServiceImpl implements UserService {
       // Check if desired new username is already taken
       String requestedUsername = updateInfo.getBasicInfo().getUsername();
       if (!username.equals(requestedUsername) && userRepository.existsByUsername(requestedUsername))
-        throw new UserAlreadyExistsException("New username is already taken: " + requestedUsername);
+        throw new ResourceAlreadyExistsException("New username is already taken: " + requestedUsername);
 
       originalUser.setUsername(updateInfo.getBasicInfo().getUsername());
       originalUser.setFirstName(updateInfo.getBasicInfo().getFirstName());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,12 @@ spring:
     hibernate:
       ddl-auto: update # creates needed tables if they don't exist
 
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 10MB
+      max-request-size: 10MB
+
   # use database instance
   datasource:
     url: jdbc:postgresql://localhost:5432/scrolls
@@ -15,6 +21,8 @@ spring:
 api:
   user:
     pageSize: 64
+  scrolls:
+    storageDirectory: ./uploads/scrolls
 
 security:
   # jwt expiration time in milliseconds

--- a/src/main/resources/scrollApi.yaml
+++ b/src/main/resources/scrollApi.yaml
@@ -132,6 +132,57 @@ paths:
               schema:
                 $ref: 'userApi.yaml#/components/responses/Error'
 
+    put:
+      tags:
+        - scrolls
+      summary: Update scroll metadata
+      description: This can only be done by `root` or `admin` users.
+      operationId: updateScroll
+
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: scrollId
+          in: path
+          description: Id of the scroll to be updated
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Update an existing scroll's metadata
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewScroll'
+
+      responses:
+        '201':
+          description: Scroll created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Scroll'
+        '400':
+          description: Invalid scroll data provided.
+          content:
+            application/json:
+              schema:
+                $ref: 'userApi.yaml#/components/responses/Error'
+        '401':
+          $ref: 'userApi.yaml#/components/responses/UnauthorizedError'
+        '403':
+          description: User is not authorized to create scrolls.
+          content:
+            application/json:
+              schema:
+                $ref: 'userApi.yaml#/components/responses/Error'
+        '409':
+          description: A scroll with this ID already exists.
+          content:
+            application/json:
+              schema:
+                $ref: 'userApi.yaml#/components/responses/Error'
+
     delete:
       tags:
         - scrolls

--- a/src/test/java/com/mf/HerculaneumTranscriptor/controller/ScrollControllerTest.java
+++ b/src/test/java/com/mf/HerculaneumTranscriptor/controller/ScrollControllerTest.java
@@ -1,0 +1,183 @@
+package com.mf.HerculaneumTranscriptor.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mf.HerculaneumTranscriptor.security.JwtAuthenticationFilter;
+import com.mf.HerculaneumTranscriptor.service.ScrollService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import scroll.dto.NewScroll;
+import scroll.dto.Scroll;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = ScrollController.class, excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class)
+})
+public class ScrollControllerTest {
+  // Disable CSRF for all requests within this test context.
+  @TestConfiguration
+  static class TestSecurityConfig {
+    @Bean
+    public SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+      http.csrf(AbstractHttpConfigurer::disable);
+      return http.build();
+    }
+  }
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockitoBean
+  private ScrollService scrollService;
+
+  private Scroll scrollDto;
+  private NewScroll newScrollDto;
+
+  private static final String SCROLL_ID = "vesuvius-scroll-1";
+
+  @BeforeEach
+  void setUp() {
+    scrollDto = new Scroll();
+    scrollDto.setScrollId(SCROLL_ID);
+    scrollDto.setDisplayName("Vesuvius Scroll 1");
+
+    newScrollDto = new NewScroll();
+    newScrollDto.setScrollId(SCROLL_ID);
+    newScrollDto.setDisplayName("Vesuvius Scroll 1");
+  }
+
+  // Tests for getAllScrolls
+
+  @Test
+  void getAllScrolls_shouldReturnScrollList_whenAuthenticated() throws Exception {
+    // Arrange
+    when(scrollService.getAllScrolls()).thenReturn(List.of(scrollDto));
+
+    // Act & Assert
+    mockMvc.perform(get("/scrolls"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].scrollId").value(SCROLL_ID));
+  }
+
+  // Tests for createScroll
+
+  @Test
+  void createScroll_shouldReturnOk_whenUserUploadsValidData() throws Exception {
+    // Arrange
+    MockMultipartFile imageFile = new MockMultipartFile(
+            "ink_image", "image.png", MediaType.IMAGE_PNG_VALUE, "dummy-image-bytes".getBytes());
+
+    // For multipart/form-data, the JSON part is sent as a string
+    String metadataJson = objectMapper.writeValueAsString(newScrollDto);
+    MockMultipartFile metadataPart = new MockMultipartFile(
+            "metadata", "", MediaType.APPLICATION_JSON_VALUE, metadataJson.getBytes());
+
+    when(scrollService.createScroll(any(NewScroll.class), any(MockMultipartFile.class))).thenReturn(scrollDto);
+
+    // Act & Assert
+    mockMvc.perform(multipart("/scrolls")
+                    .file(imageFile)
+                    .file(metadataPart))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.scrollId").value(SCROLL_ID));
+  }
+
+  @Test
+  void createScroll_shouldReturn400_whenUserUploadsInvalidData() throws Exception {
+    // Arrange
+    MockMultipartFile imageFile = new MockMultipartFile(
+            "ink_image", "image.png", MediaType.IMAGE_PNG_VALUE, "dummy-image-bytes".getBytes());
+    MockMultipartFile metadataPart = new MockMultipartFile("metadata", "", MediaType.APPLICATION_JSON_VALUE, "{}".getBytes());
+
+    when(scrollService.createScroll(any(NewScroll.class), any(MockMultipartFile.class))).thenReturn(scrollDto);
+
+    // Act & Assert
+    mockMvc.perform(multipart("/scrolls")
+                    .file(imageFile)
+                    .file(metadataPart))
+            .andExpect(status().isBadRequest());
+  }
+
+  // Tests for deleteScroll
+
+  @Test
+  void deleteScroll_shouldReturnOk_whenUserDeletesScroll() throws Exception {
+    // Arrange
+    // A void service method should be mocked with doNothing()
+    doNothing().when(scrollService).deleteScroll(SCROLL_ID);
+
+    // Act & Assert
+    mockMvc.perform(delete("/scrolls/{scrollId}", SCROLL_ID))
+            .andExpect(status().isOk());
+  }
+
+  // Tests for getScrollImage
+
+  @Test
+  void getScrollImage_shouldReturnImage_whenAuthenticated() throws Exception {
+    // Arrange
+    byte[] imageBytes = "dummy-image-content".getBytes();
+    Resource imageResource = new ByteArrayResource(imageBytes);
+    when(scrollService.getScrollImage(SCROLL_ID)).thenReturn(imageResource);
+
+    // Act & Assert
+    mockMvc.perform(get("/scrolls/{scrollId}", SCROLL_ID))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.IMAGE_PNG)) // Assuming the service sets this
+            .andExpect(content().bytes(imageBytes));
+  }
+
+  // Tests for updateScroll
+
+  @Test
+  void updateScroll_shouldReturnOk_whenUserUpdatesScroll() throws Exception {
+    // Arrange
+    when(scrollService.updateScroll(eq(SCROLL_ID), any(NewScroll.class))).thenReturn(scrollDto);
+    String requestBody = objectMapper.writeValueAsString(newScrollDto);
+
+    // Act & Assert
+    mockMvc.perform(put("/scrolls/{scrollId}", SCROLL_ID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.scrollId").value(SCROLL_ID));
+  }
+
+  @Test
+  void updateScroll_shouldReturn400_whenUserUpdatesScrollWithInvalidData() throws Exception {
+    // Arrange
+    when(scrollService.updateScroll(eq(SCROLL_ID), any(NewScroll.class))).thenReturn(scrollDto);
+    String requestBody = "{}";
+
+    // Act & Assert
+    mockMvc.perform(put("/scrolls/{scrollId}", SCROLL_ID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody))
+            .andExpect(status().isBadRequest());
+  }
+}

--- a/src/test/java/com/mf/HerculaneumTranscriptor/controller/UserControllerTest.java
+++ b/src/test/java/com/mf/HerculaneumTranscriptor/controller/UserControllerTest.java
@@ -5,7 +5,7 @@ import com.mf.HerculaneumTranscriptor.configuration.SecurityConfiguration;
 import com.mf.HerculaneumTranscriptor.domain.User;
 import com.mf.HerculaneumTranscriptor.dto.AuthenticationResponse;
 import com.mf.HerculaneumTranscriptor.exception.ResourceNotFoundException;
-import com.mf.HerculaneumTranscriptor.exception.UserAlreadyExistsException;
+import com.mf.HerculaneumTranscriptor.exception.ResourceAlreadyExistsException;
 import com.mf.HerculaneumTranscriptor.repository.UserRepository;
 import com.mf.HerculaneumTranscriptor.security.JwtUtil;
 import com.mf.HerculaneumTranscriptor.service.UserService;
@@ -150,7 +150,7 @@ public class UserControllerTest {
   @Test
   void registerNewUser_shouldReturnConflict_ifUsernameAlreadyExists() throws Exception {
     // Arrange
-    when(userService.registerNewUser(any(UserRegisterInfo.class))).thenThrow(new UserAlreadyExistsException("Username already exists"));
+    when(userService.registerNewUser(any(UserRegisterInfo.class))).thenThrow(new ResourceAlreadyExistsException("Username already exists"));
 
     // Act & Assert
     mockMvc.perform(post("/register")
@@ -273,7 +273,7 @@ public class UserControllerTest {
     // Arrange
     when(userRepository.findByUsername(USERNAME)).thenReturn(Optional.of(user));
 
-    doThrow(new UserAlreadyExistsException("Username already exists")).when(userService).updateUserProfile(USERNAME, changeInfo);
+    doThrow(new ResourceAlreadyExistsException("Username already exists")).when(userService).updateUserProfile(USERNAME, changeInfo);
     String token = jwtUtil.generateToken(USERNAME);
 
     // Act & Assert

--- a/src/test/java/com/mf/HerculaneumTranscriptor/integration/ScrollFlowIntegrationTest.java
+++ b/src/test/java/com/mf/HerculaneumTranscriptor/integration/ScrollFlowIntegrationTest.java
@@ -1,0 +1,186 @@
+package com.mf.HerculaneumTranscriptor.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mf.HerculaneumTranscriptor.domain.User;
+import com.mf.HerculaneumTranscriptor.repository.ScrollRepository;
+import com.mf.HerculaneumTranscriptor.repository.UserRepository;
+import com.mf.HerculaneumTranscriptor.security.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import scroll.dto.NewScroll;
+import user.dto.UserInfo;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional // Ensures each test runs in its own transaction and is rolled back.
+@RequiredArgsConstructor(onConstructor = @__({@Autowired}))
+public class ScrollFlowIntegrationTest {
+  @TempDir
+  static Path sharedTempDir;
+
+  @DynamicPropertySource
+  static void overrideProperties(DynamicPropertyRegistry registry) {
+    // Needed to use the temporary folder as the scroll storage location for the tests.
+    registry.add("api.scrolls.storageDirectory", () -> sharedTempDir.toString());
+  }
+
+  private final MockMvc mockMvc;
+  private final JwtUtil jwtUtil;
+  private final ObjectMapper objectMapper;
+  private final UserRepository userRepository;
+  private final ScrollRepository scrollRepository;
+  private final PasswordEncoder passwordEncoder;
+
+  private String adminToken;
+  private String userToken;
+
+  private NewScroll newScrollDto;
+
+  private final String SCROLL_ID = "vesuvius-scroll-1";
+  private final String EXISTING_SCROLL_ID = "vesuvius-scroll-2";
+
+  @BeforeEach
+  void setUp() throws IOException {
+    String userUsername = "user";
+    String adminUsername = "admin";
+    String RAW_PASSWORD = "password";
+
+    User adminUser = new User();
+    adminUser.setUsername(adminUsername);
+    adminUser.setPermissions(UserInfo.PermissionsEnum.ADMIN);
+    adminUser.setPasswordHash(passwordEncoder.encode(RAW_PASSWORD));
+    userRepository.save(adminUser);
+
+    User regularUser = new User();
+    regularUser.setUsername(userUsername);
+    regularUser.setPermissions(UserInfo.PermissionsEnum.READ);
+    regularUser.setPasswordHash(passwordEncoder.encode(RAW_PASSWORD));
+    userRepository.save(regularUser);
+
+    // Generate JWTs for each user
+    adminToken = jwtUtil.generateToken(adminUsername);
+    userToken = jwtUtil.generateToken(userUsername);
+
+    newScrollDto = new NewScroll();
+    newScrollDto.setScrollId(SCROLL_ID);
+    newScrollDto.setDisplayName("Vesuvius Scroll 1");
+
+    com.mf.HerculaneumTranscriptor.domain.Scroll scroll = new com.mf.HerculaneumTranscriptor.domain.Scroll();
+    scroll.setScrollId(EXISTING_SCROLL_ID);
+    scroll.setDisplayName("Vesuvius Challenge Scroll 2");
+    scroll.setImagePath(EXISTING_SCROLL_ID + ".png");
+    scrollRepository.save(scroll);
+
+    Path dummyFile = sharedTempDir.resolve(EXISTING_SCROLL_ID + ".png").normalize();
+    Files.writeString(dummyFile, "dummy image content");
+    assertThat(dummyFile).exists();
+  }
+
+  @Test
+  void createScroll_shouldReturn403_whenRegularUserTriesToCreate() throws Exception {
+    // Arrange
+    MockMultipartFile imageFile = new MockMultipartFile("ink_image", "image.png", MediaType.IMAGE_PNG_VALUE, "dummy-bytes".getBytes());
+    String metadataJson = objectMapper.writeValueAsString(newScrollDto);
+    MockMultipartFile metadataPart = new MockMultipartFile("metadata", "", MediaType.APPLICATION_JSON_VALUE, metadataJson.getBytes());
+
+    // Act & Assert
+    mockMvc.perform(multipart("/scrolls")
+                    .file(imageFile)
+                    .file(metadataPart)
+                    .header("Authorization", "Bearer " + userToken))
+            .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void createScroll_shouldReturnOk_whenAdminUserTriesToCreate() throws Exception {
+    // Arrange
+    MockMultipartFile imageFile = new MockMultipartFile("ink_image", "image.png", MediaType.IMAGE_PNG_VALUE, "dummy-bytes".getBytes());
+    String metadataJson = objectMapper.writeValueAsString(newScrollDto);
+    MockMultipartFile metadataPart = new MockMultipartFile("metadata", "", MediaType.APPLICATION_JSON_VALUE, metadataJson.getBytes());
+
+    // Act & Assert
+    mockMvc.perform(multipart("/scrolls")
+                    .file(imageFile)
+                    .file(metadataPart)
+                    .header("Authorization", "Bearer " + adminToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.scrollId").value(SCROLL_ID));
+
+    assertThat(scrollRepository.findByScrollId(SCROLL_ID)).isNotEmpty();
+    Path createdFile = sharedTempDir.resolve(SCROLL_ID + ".png").normalize();
+    assertThat(createdFile).exists();
+  }
+
+  @Test
+  void deleteScroll_shouldReturn403_whenRegularUserDeletesScroll() throws Exception {
+    // Act & Assert
+    mockMvc.perform(delete("/scrolls/{scrollId}", EXISTING_SCROLL_ID)
+                    .header("Authorization", "Bearer " + userToken))
+            .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void deleteScroll_shouldReturnOk_whenAdminDeletesScroll() throws Exception {
+    // Act & Assert
+    mockMvc.perform(delete("/scrolls/{scrollId}", EXISTING_SCROLL_ID)
+                    .header("Authorization", "Bearer " + adminToken))
+            .andExpect(status().isOk());
+
+    assertThat(scrollRepository.findByScrollId(EXISTING_SCROLL_ID)).isEmpty();
+    Path deletedFile = sharedTempDir.resolve(EXISTING_SCROLL_ID + ".png").normalize();
+    assertThat(deletedFile).doesNotExist();
+  }
+
+  @Test
+  void updateScroll_shouldReturnOk_whenAdminUpdatesScroll() throws Exception {
+    // Arrange
+    String requestBody = objectMapper.writeValueAsString(newScrollDto);
+
+    // Act & Assert
+    mockMvc.perform(put("/scrolls/{scrollId}", EXISTING_SCROLL_ID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody)
+                    .header("Authorization", "Bearer " + adminToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.scrollId").value(SCROLL_ID));
+
+    assertThat(scrollRepository.findByScrollId(EXISTING_SCROLL_ID)).isEmpty();
+    assertThat(scrollRepository.findByScrollId(SCROLL_ID)).isNotEmpty();
+  }
+
+  @Test
+  void updateScroll_shouldReturn403_whenRegularUserUpdatesScroll() throws Exception {
+    // Arrange
+    String requestBody = objectMapper.writeValueAsString(newScrollDto);
+
+    // Act & Assert
+    mockMvc.perform(put("/scrolls/{scrollId}", EXISTING_SCROLL_ID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody)
+                    .header("Authorization", "Bearer " + userToken))
+            .andExpect(status().isForbidden());
+  }
+}

--- a/src/test/java/com/mf/HerculaneumTranscriptor/service/ScrollServiceImplTest.java
+++ b/src/test/java/com/mf/HerculaneumTranscriptor/service/ScrollServiceImplTest.java
@@ -160,6 +160,7 @@ public class ScrollServiceImplTest {
     // Mock static Files.delete method
     try (MockedStatic<Files> mockedFiles = Mockito.mockStatic(Files.class)) {
       mockedFiles.when(() -> Files.delete(any(Path.class))).thenAnswer(invocation -> null);
+      mockedFiles.when(() -> Files.exists(any(Path.class))).thenAnswer(invocation -> true);
 
       // Act
       scrollService.deleteScroll(SCROLL_ID);
@@ -187,7 +188,6 @@ public class ScrollServiceImplTest {
   void getScrollImage_shouldReturnResource_whenScrollAndFileExist() throws IOException {
     // Arrange
     when(scrollRepository.findByScrollId(SCROLL_ID)).thenReturn(Optional.of(scroll));
-    Path expectedPath = TEST_STORAGE_LOCATION.resolve(scroll.getImagePath()).normalize();
 
     // We mock the static getResourceAsStream method
     try (MockedStatic<Files> mockedFiles = Mockito.mockStatic(Files.class)) {

--- a/src/test/java/com/mf/HerculaneumTranscriptor/service/ScrollServiceImplTest.java
+++ b/src/test/java/com/mf/HerculaneumTranscriptor/service/ScrollServiceImplTest.java
@@ -1,0 +1,152 @@
+package com.mf.HerculaneumTranscriptor.service;
+
+import com.mf.HerculaneumTranscriptor.domain.Scroll;
+import com.mf.HerculaneumTranscriptor.domain.mapper.ScrollMapper;
+import com.mf.HerculaneumTranscriptor.exception.ResourceAlreadyExistsException;
+import com.mf.HerculaneumTranscriptor.repository.ScrollRepository;
+import com.mf.HerculaneumTranscriptor.service.impl.ScrollServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import scroll.dto.NewScroll;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ScrollServiceImplTest {
+
+  @InjectMocks
+  private ScrollServiceImpl scrollService;
+
+  @Mock
+  private ScrollRepository scrollRepository;
+
+  @Mock
+  private ScrollMapper scrollMapper;
+
+  // Reusable test data objects
+  private Scroll scroll;
+  private scroll.dto.Scroll scrollDto;
+  private NewScroll newScrollDto;
+  private MockMultipartFile mockImageFile;
+  private static final Path TEST_STORAGE_LOCATION = Paths.get("test-uploads");
+
+  private static final String SCROLL_ID = "vesuvius-scroll-1";
+  private static final String DISPLAY_NAME = "Vesuvius Challenge Scroll 1";
+
+
+  @BeforeEach
+  void setUp() {
+    ReflectionTestUtils.setField(scrollService, "storageLocation", TEST_STORAGE_LOCATION);
+
+    // Create entity
+    scroll = new Scroll();
+    scroll.setId(1L);
+    scroll.setScrollId(SCROLL_ID);
+    scroll.setDisplayName(DISPLAY_NAME);
+    scroll.setImagePath(SCROLL_ID + ".png");
+
+    // Create DTOs
+    scrollDto = new scroll.dto.Scroll();
+    scrollDto.setScrollId(SCROLL_ID);
+    scrollDto.setDisplayName(DISPLAY_NAME);
+
+    newScrollDto = new NewScroll();
+    newScrollDto.setScrollId(SCROLL_ID);
+    newScrollDto.setDisplayName(DISPLAY_NAME);
+
+    // Create a mock file for upload tests
+    mockImageFile = new MockMultipartFile(
+            "inkImage",
+            "vesuvius-scroll-1.png",
+            "image/png",
+            "dummy image content".getBytes()
+    );
+  }
+
+  // Tests for getAllScrolls
+
+  @Test
+  void getAllScrolls_shouldReturnListOfScrolls_whenScrollsExist() {
+    // Arrange
+    when(scrollRepository.findAll()).thenReturn(List.of(scroll));
+    when(scrollMapper.scrollEntityToScrollDto(scroll)).thenReturn(scrollDto);
+
+    // Act
+    List<scroll.dto.Scroll> result = scrollService.getAllScrolls();
+
+    // Assert
+    assertThat(result).isNotNull();
+    assertThat(result.size()).isEqualTo(1);
+    assertThat(result.getFirst()).isEqualTo(scrollDto);
+    verify(scrollRepository, times(1)).findAll();
+  }
+
+  @Test
+  void getAllScrolls_shouldReturnEmptyList_whenNoScrollsExist() {
+    // Arrange
+    when(scrollRepository.findAll()).thenReturn(Collections.emptyList());
+
+    // Act
+    List<scroll.dto.Scroll> result = scrollService.getAllScrolls();
+
+    // Assert
+    assertThat(result).isNotNull();
+    assertThat(result.isEmpty()).isTrue();
+    verify(scrollMapper, never()).scrollEntityToScrollDto(any());
+  }
+
+  // Tests for createScroll
+
+  @Test
+  void createScroll_shouldCreateAndReturnScroll_whenIdIsAvailable() throws IOException {
+    // Arrange
+    when(scrollRepository.existsByScrollId(SCROLL_ID)).thenReturn(false);
+    when(scrollMapper.newScrollDtoToScrollEntity(newScrollDto)).thenReturn(scroll);
+    when(scrollRepository.save(scroll)).thenReturn(scroll);
+    when(scrollMapper.scrollEntityToScrollDto(scroll)).thenReturn(scrollDto);
+
+    // We need to mock static methods in `java.nio.file.Files`
+    try (MockedStatic<Files> mockedFiles = Mockito.mockStatic(Files.class)) {
+      // Act
+      scroll.dto.Scroll result = scrollService.createScroll(newScrollDto, mockImageFile);
+
+      // Assert
+      assertThat(result).isEqualTo(scrollDto);
+      verify(scrollRepository, times(1)).save(scroll);
+
+      // Verify that the file copy operation was attempted
+      mockedFiles.verify(() -> Files.copy(any(InputStream.class), any(Path.class), any()));
+    }
+  }
+
+  @Test
+  void createScroll_shouldThrowResourceAlreadyExistsException_whenIdIsTaken() {
+    // Arrange
+    when(scrollRepository.existsByScrollId(SCROLL_ID)).thenReturn(true);
+
+    // Act & Assert
+    assertThrows(ResourceAlreadyExistsException.class,
+            () -> scrollService.createScroll(newScrollDto, mockImageFile));
+
+    verify(scrollRepository, never()).save(any());
+  }
+
+}

--- a/src/test/java/com/mf/HerculaneumTranscriptor/service/UserServiceImplTest.java
+++ b/src/test/java/com/mf/HerculaneumTranscriptor/service/UserServiceImplTest.java
@@ -4,7 +4,7 @@ import com.mf.HerculaneumTranscriptor.domain.User;
 import com.mf.HerculaneumTranscriptor.domain.mapper.UserMapper;
 import com.mf.HerculaneumTranscriptor.dto.AuthenticationResponse;
 import com.mf.HerculaneumTranscriptor.exception.ResourceNotFoundException;
-import com.mf.HerculaneumTranscriptor.exception.UserAlreadyExistsException;
+import com.mf.HerculaneumTranscriptor.exception.ResourceAlreadyExistsException;
 import com.mf.HerculaneumTranscriptor.repository.UserRepository;
 import com.mf.HerculaneumTranscriptor.security.JwtUtil;
 import com.mf.HerculaneumTranscriptor.service.impl.UserServiceImpl;
@@ -173,7 +173,7 @@ public class UserServiceImplTest {
     when(userRepository.existsByUsername(USERNAME)).thenReturn(true);
 
     // Act & Assert that the expected exception is thrown
-    assertThrows(UserAlreadyExistsException.class, () -> userService.registerNewUser(userRegisterInfo));
+    assertThrows(ResourceAlreadyExistsException.class, () -> userService.registerNewUser(userRegisterInfo));
 
     // Verify that the critical method "save" was never called
     verify(userRepository, never()).save(any());
@@ -310,7 +310,7 @@ public class UserServiceImplTest {
     when(userRepository.existsByUsername("ExistingUser")).thenReturn(true);
 
     // Act & Assert
-    assertThrows(UserAlreadyExistsException.class, () -> userService.updateUserProfile(USERNAME, updateInfo));
+    assertThrows(ResourceAlreadyExistsException.class, () -> userService.updateUserProfile(USERNAME, updateInfo));
 
     // Verify that save was never called
     verify(userRepository, never()).save(any());


### PR DESCRIPTION
This pull request includes the changes necessary for uploading, editing and visualizing scroll ink prediction data.

While any user is able to query the back-end for the whole scroll catalog and ink prediction images, only administrators and the root user may create, delete or edit the details of any scroll.