### PR TITLE
Scroll API integration with Cloudinary for image cloud storage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,15 @@
     </properties>
 	<dependencies>
 
-		<!-- Dependencies needed JWT generation and validation -->
+        <!-- Dependencies needed for cloud storage of scroll images -->
+
+        <dependency>
+            <groupId>com.cloudinary</groupId>
+            <artifactId>cloudinary-http44</artifactId>
+            <version>1.39.0</version>
+        </dependency>
+
+		<!-- Dependencies needed for JWT generation and validation -->
 
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>

--- a/src/main/java/com/mf/HerculaneumTranscriptor/configuration/CloudinaryConfiguration.java
+++ b/src/main/java/com/mf/HerculaneumTranscriptor/configuration/CloudinaryConfiguration.java
@@ -1,0 +1,28 @@
+package com.mf.HerculaneumTranscriptor.configuration;
+
+import com.cloudinary.Cloudinary;
+import com.cloudinary.utils.ObjectUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CloudinaryConfiguration {
+
+  @Value("${cloudinary.cloud_name:null}")
+  private String cloudName;
+
+  @Value("${cloudinary.api_key:null}")
+  private String apiKey;
+
+  @Value("${cloudinary.api_secret:null}")
+  private String apiSecret;
+
+  @Bean
+  public Cloudinary cloudinary() {
+    return new Cloudinary(ObjectUtils.asMap(
+            "cloud_name", cloudName,
+            "api_key", apiKey,
+            "api_secret", apiSecret));
+  }
+}

--- a/src/main/java/com/mf/HerculaneumTranscriptor/controller/ScrollController.java
+++ b/src/main/java/com/mf/HerculaneumTranscriptor/controller/ScrollController.java
@@ -3,6 +3,8 @@ package com.mf.HerculaneumTranscriptor.controller;
 import com.mf.HerculaneumTranscriptor.service.ScrollService;
 import lombok.AllArgsConstructor;
 import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -38,8 +40,15 @@ public class ScrollController implements ScrollsApi {
 
   @Override
   public ResponseEntity<Resource> getScrollImage(String scrollId) throws IOException {
-    Resource inkImage = scrollService.getScrollImage(scrollId);
-    return ResponseEntity.ok(inkImage);
+    Resource inkImageResource = scrollService.getScrollImage(scrollId);
+
+    if (inkImageResource instanceof UrlResource){
+      return ResponseEntity.status(HttpStatus.FOUND).location(
+              inkImageResource.getURI()
+      ).build();
+    }
+
+    return ResponseEntity.ok(inkImageResource);
   }
 
   @Override

--- a/src/main/java/com/mf/HerculaneumTranscriptor/controller/ScrollController.java
+++ b/src/main/java/com/mf/HerculaneumTranscriptor/controller/ScrollController.java
@@ -3,7 +3,6 @@ package com.mf.HerculaneumTranscriptor.controller;
 import com.mf.HerculaneumTranscriptor.service.ScrollService;
 import lombok.AllArgsConstructor;
 import org.springframework.core.io.Resource;
-import org.springframework.core.io.UrlResource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -13,6 +12,7 @@ import scroll.dto.NewScroll;
 import scroll.dto.Scroll;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.List;
 
 @RestController
@@ -41,14 +41,14 @@ public class ScrollController implements ScrollsApi {
   @Override
   public ResponseEntity<Resource> getScrollImage(String scrollId) throws IOException {
     Resource inkImageResource = scrollService.getScrollImage(scrollId);
-
-    if (inkImageResource instanceof UrlResource){
-      return ResponseEntity.status(HttpStatus.FOUND).location(
-              inkImageResource.getURI()
-      ).build();
-    }
-
     return ResponseEntity.ok(inkImageResource);
+  }
+
+  @Override
+  public ResponseEntity<Void> getScrollImageURL(String scrollId) {
+    URI imageURL = scrollService.getScrollImageURL(scrollId);
+
+    return ResponseEntity.status(HttpStatus.FOUND).location(imageURL).build();
   }
 
   @Override

--- a/src/main/java/com/mf/HerculaneumTranscriptor/service/ScrollService.java
+++ b/src/main/java/com/mf/HerculaneumTranscriptor/service/ScrollService.java
@@ -9,6 +9,7 @@ import scroll.dto.NewScroll;
 import scroll.dto.Scroll;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.List;
 
 /**
@@ -50,7 +51,17 @@ public interface ScrollService {
   void deleteScroll(String scrollId) throws ResourceNotFoundException, IOException;
 
   /**
-   * Retrieves the ink prediction image for a specific scroll as a loadable resource.
+   * Retrieves the ink prediction image URL for a specific scroll.
+   * Any authenticated user can invoke this method.
+   *
+   * @param scrollId The unique identifier of the scroll.
+   * @return A URL response object holding the URL.
+   * @throws com.mf.HerculaneumTranscriptor.exception.ResourceNotFoundException if the scroll does not exist.
+   */
+  URI getScrollImageURL(String scrollId) throws ResourceNotFoundException;
+
+  /**
+   * Retrieves a locally saved ink prediction image for a specific scroll as a loadable resource.
    * Any authenticated user can download the image.
    *
    * @param scrollId The unique identifier of the scroll.

--- a/src/main/java/com/mf/HerculaneumTranscriptor/service/impl/ScrollServiceImpl.java
+++ b/src/main/java/com/mf/HerculaneumTranscriptor/service/impl/ScrollServiceImpl.java
@@ -1,5 +1,7 @@
 package com.mf.HerculaneumTranscriptor.service.impl;
 
+import com.cloudinary.Cloudinary;
+import com.cloudinary.utils.ObjectUtils;
 import com.mf.HerculaneumTranscriptor.domain.mapper.ScrollMapper;
 import com.mf.HerculaneumTranscriptor.exception.ResourceAlreadyExistsException;
 import com.mf.HerculaneumTranscriptor.exception.ResourceNotFoundException;
@@ -9,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
@@ -17,10 +20,14 @@ import scroll.dto.Scroll;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.StreamSupport;
 
 @Service
@@ -28,9 +35,38 @@ import java.util.stream.StreamSupport;
 public class ScrollServiceImpl implements ScrollService {
   private final ScrollRepository scrollRepository;
   private final ScrollMapper scrollMapper;
+  private final Cloudinary cloudinary;
 
   @Value("${api.scrolls.storageDirectory}")
   private Path storageLocation;
+  @Value("${api.scrolls.useCloud}")
+  private Boolean useCloudStorage;
+
+  /**
+   * Validates if a given string is a valid URL.
+   *
+   * @param urlString The string to validate.
+   * @return true if the string is a valid URL, false otherwise.
+   */
+  boolean isValidURL(String urlString) {
+    if (urlString == null || urlString.isBlank()) {
+      return false;
+    }
+    try {
+      URI uri = new URI(urlString);
+
+      // Check if the URI has a scheme and host.
+      if (uri.getScheme() == null || uri.getHost() == null)
+        return false;
+
+      uri.toURL();
+
+      return true;
+    } catch (URISyntaxException | MalformedURLException | IllegalArgumentException e) {
+      // If any part fails, it's not a valid URL.
+      return false;
+    }
+  }
 
   @Override
   public List<Scroll> getAllScrolls() {
@@ -45,21 +81,36 @@ public class ScrollServiceImpl implements ScrollService {
 
     com.mf.HerculaneumTranscriptor.domain.Scroll newScroll = scrollMapper.newScrollDtoToScrollEntity(metadata);
 
-    if (!Files.exists(storageLocation))
-      Files.createDirectories(storageLocation);
+    String imgPath;
+    if (useCloudStorage){
+      Map uploadResult = cloudinary.uploader().upload(inkImage.getBytes(),
+              ObjectUtils.asMap(
+                      // public id is the scroll id
+                      "public_id", metadata.getScrollId(),
+                      "type", "private",
+                      "folder", storageLocation.toString()
+              ));
 
-    String fileExtension = StringUtils.getFilenameExtension(inkImage.getOriginalFilename());
-    String filename = metadata.getScrollId() + "." + fileExtension;
-    Path destinationFile = storageLocation.resolve(filename).normalize();
+      // Get the secure URL of the uploaded image from the Cloudinary response
+      imgPath = uploadResult.get("secure_url").toString();
 
-    // Use a try-with-resources block to ensure the input stream is closed automatically
-    try (InputStream inputStream = inkImage.getInputStream()) {
-      // Copy the file's input stream to the target location.
-      // REPLACE_EXISTING ensures that if a file with the same name somehow exists, it's overwritten.
-      Files.copy(inputStream, destinationFile, StandardCopyOption.REPLACE_EXISTING);
+    } else {
+      if (!Files.exists(storageLocation))
+        Files.createDirectories(storageLocation);
+
+      String fileExtension = StringUtils.getFilenameExtension(inkImage.getOriginalFilename());
+      imgPath = metadata.getScrollId() + "." + fileExtension;
+      Path destinationFile = storageLocation.resolve(imgPath).normalize();
+
+      // Use a try-with-resources block to ensure the input stream is closed automatically
+      try (InputStream inputStream = inkImage.getInputStream()) {
+        // Copy the file's input stream to the target location.
+        // REPLACE_EXISTING ensures that if a file with the same name somehow exists, it's overwritten.
+        Files.copy(inputStream, destinationFile, StandardCopyOption.REPLACE_EXISTING);
+      }
     }
 
-    newScroll.setImagePath(filename);
+    newScroll.setImagePath(imgPath);
 
     // Important to return savedScroll as creation date is set automatically by the DB
     com.mf.HerculaneumTranscriptor.domain.Scroll savedScroll = scrollRepository.save(newScroll);
@@ -73,7 +124,17 @@ public class ScrollServiceImpl implements ScrollService {
 
     scrollRepository.delete(scroll); // Deletes the metadata from the DB
 
-    Path filePath = storageLocation.resolve(scroll.getImagePath()).normalize();
+    String imagePath = scroll.getImagePath();
+
+    // If instead of a path we have a URL, delete image from cloud storage
+    if (isValidURL(imagePath)){
+      // We delete the image from Cloudinary using its public_id (its folder + scrollId)
+      String publicId = storageLocation.toString() + "/" + scrollId;
+      cloudinary.uploader().destroy(publicId, ObjectUtils.asMap("resource_type", "image", "invalidate", true, "type", "private"));
+      return;
+    }
+
+    Path filePath = storageLocation.resolve(imagePath).normalize();
 
     // In the improbable case the image does not exist, do not try to delete it
     if (Files.exists(filePath))
@@ -84,6 +145,28 @@ public class ScrollServiceImpl implements ScrollService {
   public Resource getScrollImage(String scrollId) throws ResourceNotFoundException, IOException {
     com.mf.HerculaneumTranscriptor.domain.Scroll scroll = scrollRepository.findByScrollId(scrollId)
             .orElseThrow(() -> new ResourceNotFoundException("Scroll not found"));
+
+    String imagePath = scroll.getImagePath();
+
+    // If instead of a path we have a URL, return signed URL to image from cloud storage
+    if (isValidURL(imagePath)){
+      try {
+        // Define the options for the URL
+        Map options = ObjectUtils.asMap(
+                "resource_type", "image",
+                "expires_at", (System.currentTimeMillis() / 1000L) + 5*60L // Expires in 5 minutes (Unix epoch time in seconds)
+        );
+
+        // Generate the signed URL
+        String signedUrl = cloudinary.privateDownload(storageLocation.toString() + "/" + scrollId, "png", options);
+
+        return new UrlResource(signedUrl);
+
+      } catch (Exception e) {
+        // This can happen if credentials are bad or there's a network issue with Cloudinary
+        throw new RuntimeException("Could not generate secure image URL.", e);
+      }
+    }
 
     Path filePath = storageLocation.resolve(scroll.getImagePath()).normalize();
     InputStream in = Files.newInputStream(filePath);

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -7,3 +7,7 @@ spring:
     url: jdbc:h2:mem:db;DB_CLOSE_DELAY=-1
     username: sa
     password: sa
+
+api:
+  scrolls:
+    useCloud: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,7 @@ api:
     pageSize: 64
   scrolls:
     storageDirectory: ./uploads/scrolls
+    useCloud: true
 
 security:
   # jwt expiration time in milliseconds

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,12 +23,12 @@ api:
     pageSize: 64
   scrolls:
     storageDirectory: ./uploads/scrolls
-    useCloud: true
+    useCloud: false
 
 security:
   # jwt expiration time in milliseconds
   expiration: 3600000 # (1 hour)
-  # secret base64 string for jwt key generation
+  # secret 128 hex key for jwt encryption
   secret: 074575585bd48a11cf09a250c39c8bfc32878f11d057b3bf265cd1901563cd1a
   rootProfile:
     username: root

--- a/src/main/resources/scrollApi.yaml
+++ b/src/main/resources/scrollApi.yaml
@@ -96,7 +96,7 @@ paths:
               schema:
                 $ref: 'userApi.yaml#/components/responses/Error'
 
-  /scrolls/{scrollId}:
+  /scrolls/{scrollId}/local-download:
     get:
       tags:
         - scrolls
@@ -123,6 +123,37 @@ paths:
               schema:
                 type: string
                 format: binary
+        '401':
+          $ref: 'userApi.yaml#/components/responses/UnauthorizedError'
+        '404':
+          description: Scroll or its image not found.
+          content:
+            application/json:
+              schema:
+                $ref: 'userApi.yaml#/components/responses/Error'
+
+  /scrolls/{scrollId}:
+    get:
+      tags:
+        - scrolls
+      summary: Get a scroll's ink prediction image URL location
+      description: |
+        Retrieves the ink prediction image URL a specific scroll.
+        It could point to Cloudinary or to a local download endpoint.
+      operationId: getScrollImageURL
+      security:
+        - bearerAuth: [ ]
+      parameters:
+        - name: scrollId
+          in: path
+          description: The unique identifier of the scroll.
+          required: true
+          schema:
+            type: string
+            example: 'vesuvius-scroll-1'
+      responses:
+        '302':
+          description: Contains the scroll's ink prediction image URL.
         '401':
           $ref: 'userApi.yaml#/components/responses/UnauthorizedError'
         '404':

--- a/src/test/java/com/mf/HerculaneumTranscriptor/controller/ScrollControllerTest.java
+++ b/src/test/java/com/mf/HerculaneumTranscriptor/controller/ScrollControllerTest.java
@@ -23,6 +23,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import scroll.dto.NewScroll;
 import scroll.dto.Scroll;
 
+import java.net.URI;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -146,10 +147,24 @@ public class ScrollControllerTest {
     when(scrollService.getScrollImage(SCROLL_ID)).thenReturn(imageResource);
 
     // Act & Assert
-    mockMvc.perform(get("/scrolls/{scrollId}", SCROLL_ID))
+    mockMvc.perform(get("/scrolls/{scrollId}/local-download", SCROLL_ID))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.IMAGE_PNG)) // Assuming the service sets this
             .andExpect(content().bytes(imageBytes));
+  }
+
+  // Tests for getScrollImageURL
+
+  @Test
+  void getScrollImageURL_shouldReturnURL_whenAuthenticated() throws Exception {
+    // Arrange
+    URI imageURI = new URI("https://cloudinary.com/signed/url/for/cloud-scroll-1");
+    when(scrollService.getScrollImageURL(SCROLL_ID)).thenReturn(imageURI);
+
+    // Act & Assert
+    mockMvc.perform(get("/scrolls/{scrollId}", SCROLL_ID))
+            .andExpect(status().isFound())
+            .andExpect(header().string("Location", imageURI.toString()));
   }
 
   // Tests for updateScroll

--- a/src/test/java/com/mf/HerculaneumTranscriptor/service/ScrollServiceImplTest.java
+++ b/src/test/java/com/mf/HerculaneumTranscriptor/service/ScrollServiceImplTest.java
@@ -55,6 +55,7 @@ public class ScrollServiceImplTest {
   @BeforeEach
   void setUp() {
     ReflectionTestUtils.setField(scrollService, "storageLocation", TEST_STORAGE_LOCATION);
+    ReflectionTestUtils.setField(scrollService, "useCloudStorage", false);
 
     // Create entity
     scroll = new Scroll();

--- a/src/test/java/com/mf/HerculaneumTranscriptor/service/ScrollServiceImplTest.java
+++ b/src/test/java/com/mf/HerculaneumTranscriptor/service/ScrollServiceImplTest.java
@@ -1,11 +1,13 @@
 package com.mf.HerculaneumTranscriptor.service;
 
+import com.cloudinary.Cloudinary;
 import com.mf.HerculaneumTranscriptor.domain.Scroll;
 import com.mf.HerculaneumTranscriptor.domain.mapper.ScrollMapper;
 import com.mf.HerculaneumTranscriptor.exception.ResourceAlreadyExistsException;
 import com.mf.HerculaneumTranscriptor.exception.ResourceNotFoundException;
 import com.mf.HerculaneumTranscriptor.repository.ScrollRepository;
 import com.mf.HerculaneumTranscriptor.service.impl.ScrollServiceImpl;
+import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,10 +16,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.io.Resource;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import scroll.dto.NewScroll;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -40,6 +45,9 @@ public class ScrollServiceImplTest {
 
   @Mock
   private ScrollMapper scrollMapper;
+
+  @Mock
+  private Cloudinary cloudinary;
 
   // Reusable test data objects
   private Scroll scroll;
@@ -211,6 +219,65 @@ public class ScrollServiceImplTest {
 
     // Act & Assert
     assertThrows(ResourceNotFoundException.class, () -> scrollService.getScrollImage(SCROLL_ID));
+  }
+
+  // Tests for getScrollImageURL
+
+  @Test
+  void getScrollImageUrl_shouldReturnSignedUrl_whenImagePathIsCloudUrl() throws Exception {
+    // Arrange
+    String expectedSignedUrl = "https://cloudinary.com/signed/url/for/cloud-scroll-1";
+    scroll.setImagePath("https://res.cloudinary.com/your-cloud/image/upload/s--TOKEN--/v1678886000/scrolls/vesuvius-scroll-1.png");
+
+    // Mock the repository to return the scroll with a cloud URL
+    when(scrollRepository.findByScrollId(SCROLL_ID)).thenReturn(Optional.of(scroll));
+
+    // Mock the Cloudinary SDK calls
+    when(cloudinary.privateDownload(any(), any(), anyMap())).thenReturn(expectedSignedUrl);
+
+
+    // Act
+    URI resultUri = scrollService.getScrollImageURL(SCROLL_ID);
+
+    // Assert
+    assertThat(resultUri).isNotNull();
+    assertThat(resultUri.toString()).isEqualTo(expectedSignedUrl);
+  }
+
+  @Test
+  void getScrollImageUrl_shouldReturnLocalDownloadUrl_whenImagePathIsLocal() {
+    // Arrange
+    // Mock the repository to return the scroll with a local path
+    when(scrollRepository.findByScrollId(SCROLL_ID)).thenReturn(Optional.of(scroll));
+
+    // IMPORTANT: ServletUriComponentsBuilder needs a mock HTTP request to get the context path.
+    // We need to mock the static methods of RequestContextHolder.
+    HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+    when(mockRequest.getContextPath()).thenReturn(""); // For "http://localhost"
+    when(mockRequest.getScheme()).thenReturn("http");
+    when(mockRequest.getServerName()).thenReturn("localhost");
+    when(mockRequest.getServerPort()).thenReturn(8080);
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(mockRequest));
+
+
+    // Act
+    URI resultUri = scrollService.getScrollImageURL(SCROLL_ID);
+
+    // Assert
+    assertThat(resultUri).isNotNull();
+    assertThat(resultUri.toString()).isEqualTo("http://localhost:8080/scrolls/" + SCROLL_ID+ "/local-download");
+
+    // Clean up the static mock
+    RequestContextHolder.resetRequestAttributes();
+  }
+
+  @Test
+  void getScrollImageUrl_shouldThrowResourceNotFoundException_whenScrollDoesNotExist() {
+    // Arrange
+    when(scrollRepository.findByScrollId(SCROLL_ID)).thenReturn(Optional.empty());
+
+    // Act & Assert
+    assertThrows(ResourceNotFoundException.class, () -> scrollService.getScrollImageURL(SCROLL_ID));
   }
 
   // Tests for updateScroll


### PR DESCRIPTION
Previously, the Scroll API only persisted scroll images in local storage, relying on the server's file system.

This could present issues in order when deploying the service on environments without file system data persistence, as well as when trying to horizontally scale the service across many different devices.

In order to solve this, image cloud storage through Cloudinary is introduced. This cloud service was chosen due to its permissive free tier, as this is an educational project.